### PR TITLE
Add multiplayer rooms with websocket support

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,36 +1,141 @@
+import asyncio
 import uvicorn
-from fastapi import FastAPI
-from fastapi.responses import HTMLResponse
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse, JSONResponse
+from pydantic import BaseModel
 from starlette.staticfiles import StaticFiles
-import random
-import re
+from typing import Dict, List
+
 from core.model_loader import ModelLoader
-from core.game_engine import CemantixEngine
+from core.rooms import RoomManager, RoomState
+
 
 app = FastAPI()
 
 loader = ModelLoader("model/frWac_no_postag_phrase_500_cbow_cut10_stripped.bin")
 model = loader.load()
+room_manager = RoomManager(model)
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
 
+class CreateRoomRequest(BaseModel):
+    player_name: str
+    mode: str = "coop"
 
-def get_simple_random_word(model):
-    vocab = list(model.key_to_index.keys())
 
-    # Filtre : mots simples uniquement
-    simple_words = [
-        w for w in vocab
-        if 4 <= len(w) <= 8                 # mots courts
-        and re.fullmatch(r"[a-zàâçéèêëîïôûùüÿñæœ]+", w)  # pas de caractères bizarres
+class GuessRequest(BaseModel):
+    word: str
+    player_name: str
+
+
+class RoomConnectionManager:
+    def __init__(self):
+        self.active_connections: Dict[str, List[WebSocket]] = {}
+        self.players: Dict[WebSocket, str] = {}
+        self.lock = asyncio.Lock()
+
+    async def connect(self, room_id: str, websocket: WebSocket, player_name: str):
+        await websocket.accept()
+        async with self.lock:
+            self.active_connections.setdefault(room_id, []).append(websocket)
+            self.players[websocket] = player_name
+
+    def disconnect(self, room_id: str, websocket: WebSocket):
+        if room_id in self.active_connections and websocket in self.active_connections[room_id]:
+            self.active_connections[room_id].remove(websocket)
+        if websocket in self.players:
+            del self.players[websocket]
+
+    async def broadcast(self, room_id: str, message: Dict):
+        connections = list(self.active_connections.get(room_id, []))
+        for connection in connections:
+            try:
+                await connection.send_json(message)
+            except Exception:
+                self.disconnect(room_id, connection)
+
+
+connections = RoomConnectionManager()
+
+
+def normalize_mode(mode: str) -> str:
+    if mode not in {"coop", "race"}:
+        return "coop"
+    return mode
+
+
+def build_scoreboard(room: RoomState):
+    scoreboard = [
+        {
+            "player_name": name,
+            "attempts": stats.attempts,
+            "best_similarity": stats.best_similarity,
+        }
+        for name, stats in room.players.items()
     ]
+    scoreboard.sort(key=lambda x: (-x["best_similarity"], -x["attempts"]))
+    return scoreboard
 
-    return random.choice(simple_words)
 
-random_word = get_simple_random_word(model)
-engine = CemantixEngine(model)
-engine.new_game(random_word)
-print(random_word)
+def build_history_payload(room: RoomState):
+    history_payload = []
+    for entry in room.history:
+        progression = int(round(entry.similarity * 1000)) if entry.similarity is not None else 0
+        history_payload.append(
+            {
+                "word": entry.word,
+                "player_name": entry.player_name,
+                "temperature": entry.temperature,
+                "progression": progression,
+            }
+        )
+    return history_payload
+
+
+def build_victory_message(room: RoomState, player_name: str, victory: bool):
+    if not victory:
+        return None
+    return {
+        "type": "victory",
+        "mode": room.mode,
+        "player_name": player_name,
+        "room_id": room.room_id,
+    }
+
+
+def process_guess(room: RoomState, word: str, player_name: str):
+    if room.mode == "race" and room.locked:
+        return {"error": "room_locked", "message": "Cette room est verrouillée"}
+
+    result = room.engine.guess(word)
+    similarity = result.get("similarity") if result.get("exists") else None
+    temperature = result.get("temperature") if result.get("exists") else None
+
+    room.record_guess(word, player_name, similarity, temperature)
+
+    victory = False
+    if result.get("exists") and similarity is not None and similarity >= 0.99:
+        victory = True
+        if room.mode == "race":
+            room.locked = True
+
+    room_manager.persist_room(room.room_id)
+
+    progression = int(round(similarity * 1000)) if similarity is not None else 0
+    guess_payload = {
+        "type": "guess",
+        "word": word,
+        "player_name": player_name,
+        "temperature": temperature,
+        "similarity": similarity,
+        "progression": progression,
+    }
+    return {
+        "result": {**result, "progression": progression},
+        "guess_payload": guess_payload,
+        "scoreboard": build_scoreboard(room),
+        "victory": victory,
+    }
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -38,9 +143,124 @@ def home():
     with open("static/index.html", "r", encoding="utf-8") as f:
         return f.read()
 
-@app.post("/guess")
-def guess(word: str):
-    return engine.guess(word)
+
+@app.post("/rooms")
+def create_room(payload: CreateRoomRequest):
+    mode = normalize_mode(payload.mode)
+    room = room_manager.create_room(mode, payload.player_name)
+    return {"room_id": room.room_id, "mode": room.mode, "scoreboard": build_scoreboard(room)}
+
+
+@app.post("/rooms/{room_id}/guess")
+async def guess(room_id: str, payload: GuessRequest):
+    room = room_manager.get_room(room_id)
+    if not room:
+        return JSONResponse(status_code=404, content={"error": "room_not_found", "message": "Room inconnue"})
+
+    result_data = process_guess(room, payload.word.strip().lower(), payload.player_name)
+    if result_data.get("error"):
+        return JSONResponse(status_code=400, content=result_data)
+
+    await connections.broadcast(room_id, result_data["guess_payload"])
+    victory_message = build_victory_message(room, payload.player_name, result_data["victory"])
+    await connections.broadcast(
+        room_id,
+        {
+            "type": "scoreboard_update",
+            "scoreboard": result_data["scoreboard"],
+            "mode": room.mode,
+            "locked": room.locked,
+            "victory": result_data["victory"],
+            "winner": payload.player_name if result_data["victory"] else None,
+        },
+    )
+    if victory_message:
+        await connections.broadcast(room_id, victory_message)
+
+    return {
+        **result_data["result"],
+        "scoreboard": result_data["scoreboard"],
+        "mode": room.mode,
+        "locked": room.locked,
+    }
+
+
+@app.websocket("/rooms/{room_id}/ws")
+async def websocket_endpoint(websocket: WebSocket, room_id: str):
+    player_name = websocket.query_params.get("player_name")
+    room = room_manager.get_room(room_id)
+
+    if not player_name:
+        await websocket.accept()
+        await websocket.send_json({"error": "missing_player_name", "message": "Pseudo requis"})
+        await websocket.close()
+        return
+
+    if not room:
+        await websocket.accept()
+        await websocket.send_json({"error": "room_not_found", "message": "Room inconnue"})
+        await websocket.close()
+        return
+
+    await connections.connect(room_id, websocket, player_name)
+    room.add_player(player_name)
+    room_manager.persist_room(room.room_id)
+    await connections.broadcast(
+        room_id,
+        {
+            "type": "scoreboard_update",
+            "scoreboard": build_scoreboard(room),
+            "mode": room.mode,
+            "locked": room.locked,
+            "victory": False,
+            "winner": None,
+        },
+    )
+
+    try:
+        await websocket.send_json(
+            {
+                "type": "state_sync",
+                "history": build_history_payload(room),
+                "scoreboard": build_scoreboard(room),
+                "mode": room.mode,
+                "locked": room.locked,
+            }
+        )
+
+        while True:
+            data = await websocket.receive_json()
+            word = data.get("word")
+            if not word:
+                await websocket.send_json({"type": "error", "error": "invalid_payload", "message": "Mot manquant"})
+                continue
+
+            result_data = process_guess(room, word.strip().lower(), player_name)
+            if result_data.get("error"):
+                await websocket.send_json(result_data)
+                continue
+
+            await connections.broadcast(room_id, result_data["guess_payload"])
+            victory_message = build_victory_message(room, player_name, result_data["victory"])
+            scoreboard_payload = {
+                "type": "scoreboard_update",
+                "scoreboard": result_data["scoreboard"],
+                "mode": room.mode,
+                "locked": room.locked,
+                "victory": result_data["victory"],
+                "winner": player_name if result_data["victory"] else None,
+            }
+            await connections.broadcast(room_id, scoreboard_payload)
+            if victory_message:
+                await connections.broadcast(room_id, victory_message)
+
+            await websocket.send_json({"type": "ack", **result_data["result"]})
+    except WebSocketDisconnect:
+        connections.disconnect(room_id, websocket)
+    except Exception:
+        connections.disconnect(room_id, websocket)
+        raise
+
 
 if __name__ == "__main__":
     uvicorn.run("app:app", host="0.0.0.0", port=1256, reload=True)

--- a/core/rooms.py
+++ b/core/rooms.py
@@ -1,0 +1,168 @@
+import json
+import os
+import random
+import re
+import uuid
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from core.game_engine import CemantixEngine
+
+
+def get_simple_random_word(model):
+    vocab = list(model.key_to_index.keys())
+    simple_words = [
+        w
+        for w in vocab
+        if 4 <= len(w) <= 8
+        and re.fullmatch(r"[a-zàâçéèêëîïôûùüÿñæœ]+", w)
+    ]
+    return random.choice(simple_words)
+
+
+@dataclass
+class PlayerStats:
+    attempts: int = 0
+    best_similarity: float = 0.0
+
+    def to_dict(self):
+        return {
+            "attempts": self.attempts,
+            "best_similarity": self.best_similarity,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict):
+        return cls(
+            attempts=data.get("attempts", 0),
+            best_similarity=data.get("best_similarity", 0.0),
+        )
+
+
+@dataclass
+class GuessEntry:
+    word: str
+    player_name: str
+    similarity: Optional[float]
+    temperature: Optional[float]
+
+    def to_dict(self):
+        return {
+            "word": self.word,
+            "player_name": self.player_name,
+            "similarity": self.similarity,
+            "temperature": self.temperature,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict):
+        return cls(
+            word=data["word"],
+            player_name=data["player_name"],
+            similarity=data.get("similarity"),
+            temperature=data.get("temperature"),
+        )
+
+
+@dataclass
+class RoomState:
+    room_id: str
+    target_word: str
+    engine: CemantixEngine
+    mode: str = "coop"
+    locked: bool = False
+    players: Dict[str, PlayerStats] = field(default_factory=dict)
+    history: List[GuessEntry] = field(default_factory=list)
+
+    def add_player(self, player_name: str):
+        if player_name not in self.players:
+            self.players[player_name] = PlayerStats()
+
+    def record_guess(self, word: str, player_name: str, similarity: Optional[float], temperature: Optional[float]):
+        self.add_player(player_name)
+        player = self.players[player_name]
+        player.attempts += 1
+        if similarity is not None and similarity > player.best_similarity:
+            player.best_similarity = similarity
+        self.history.append(
+            GuessEntry(
+                word=word,
+                player_name=player_name,
+                similarity=similarity,
+                temperature=temperature,
+            )
+        )
+
+    def to_dict(self):
+        return {
+            "room_id": self.room_id,
+            "target_word": self.target_word,
+            "mode": self.mode,
+            "locked": self.locked,
+            "players": {name: stats.to_dict() for name, stats in self.players.items()},
+            "history": [entry.to_dict() for entry in self.history],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict, model):
+        engine = CemantixEngine(model)
+        engine.new_game(data["target_word"])
+        room = cls(
+            room_id=data["room_id"],
+            target_word=data["target_word"],
+            engine=engine,
+            mode=data.get("mode", "coop"),
+            locked=data.get("locked", False),
+        )
+        room.players = {name: PlayerStats.from_dict(stats) for name, stats in data.get("players", {}).items()}
+        room.history = [GuessEntry.from_dict(entry) for entry in data.get("history", [])]
+        return room
+
+
+class RoomManager:
+    def __init__(self, model, state_path: str = "rooms_state.json"):
+        self.model = model
+        self.state_path = state_path
+        self.rooms: Dict[str, RoomState] = {}
+        self.load_state()
+
+    def load_state(self):
+        if not os.path.exists(self.state_path):
+            return
+        try:
+            with open(self.state_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return
+
+        for room_data in data.get("rooms", []):
+            room = RoomState.from_dict(room_data, self.model)
+            self.rooms[room.room_id] = room
+
+    def save_state(self):
+        payload = {"rooms": [room.to_dict() for room in self.rooms.values()]}
+        with open(self.state_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+
+    def create_room(self, mode: str, creator_name: str) -> RoomState:
+        room_id = uuid.uuid4().hex[:8]
+        target_word = get_simple_random_word(self.model)
+        engine = CemantixEngine(self.model)
+        engine.new_game(target_word)
+        room = RoomState(room_id=room_id, target_word=target_word, engine=engine, mode=mode)
+        room.add_player(creator_name)
+        self.rooms[room_id] = room
+        self.save_state()
+        return room
+
+    def get_room(self, room_id: str) -> Optional[RoomState]:
+        return self.rooms.get(room_id)
+
+    def delete_room(self, room_id: str):
+        if room_id in self.rooms:
+            del self.rooms[room_id]
+            self.save_state()
+
+    def persist_room(self, room_id: str):
+        if room_id in self.rooms:
+            self.save_state()

--- a/static/index.html
+++ b/static/index.html
@@ -31,6 +31,28 @@
 
         <h1>Cémantix</h1>
 
+        <div class="room-panel">
+            <div class="room-form">
+                <label>Votre pseudo
+                    <input id="player-name" type="text" placeholder="Choisissez un pseudo">
+                </label>
+                <label>Mode
+                    <select id="mode-select">
+                        <option value="coop">Coop</option>
+                        <option value="race">Course</option>
+                    </select>
+                </label>
+                <label>ID de room
+                    <input id="room-id-input" type="text" placeholder="Laisser vide pour créer">
+                </label>
+            </div>
+            <div class="room-actions">
+                <button id="create-room" type="button">Créer une room</button>
+                <button id="join-room" type="button">Rejoindre</button>
+            </div>
+            <div id="room-info" class="room-info"></div>
+        </div>
+
         <form id="form">
             <input id="word" type="text" placeholder="Tapez un mot..." autofocus>
             <button type="submit">Tester</button>
@@ -39,6 +61,11 @@
         <div id="messages" class="messages"></div>
 
         <div id="history"></div>
+    </div>
+
+    <div class="scoreboard-panel">
+        <h2>Scoreboard</h2>
+        <div id="scoreboard"></div>
     </div>
 
 </div>

--- a/static/script.js
+++ b/static/script.js
@@ -1,76 +1,202 @@
 const form = document.getElementById("form");
 const input = document.getElementById("word");
 const history = document.getElementById("history");
+const scoreboard = document.getElementById("scoreboard");
+const roomInfo = document.getElementById("room-info");
+const createRoomBtn = document.getElementById("create-room");
+const joinRoomBtn = document.getElementById("join-room");
+const roomIdInput = document.getElementById("room-id-input");
+const playerNameInput = document.getElementById("player-name");
+const modeSelect = document.getElementById("mode-select");
 
-let entries = []; // stockage interne avant affichage
+let entries = [];
+let currentRoomId = null;
+let currentMode = "coop";
+let roomLocked = false;
+let websocket = null;
+
+createRoomBtn.addEventListener("click", async () => {
+    const playerName = playerNameInput.value.trim();
+    if (!playerName) {
+        addHistoryMessage("Choisissez un pseudo pour créer une room");
+        return;
+    }
+
+    const mode = modeSelect.value;
+    const res = await fetch(`/rooms`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ player_name: playerName, mode })
+    });
+
+    const data = await res.json();
+    if (!res.ok) {
+        addHistoryMessage(data.message || "Impossible de créer la room");
+        return;
+    }
+
+    currentRoomId = data.room_id;
+    currentMode = data.mode;
+    roomIdInput.value = data.room_id;
+    entries = [];
+    renderHistory();
+    renderScoreboard(data.scoreboard || []);
+    setRoomInfo(`Room ${data.room_id} (${data.mode}) créée.`);
+    openWebsocket(playerName);
+});
+
+joinRoomBtn.addEventListener("click", () => {
+    const playerName = playerNameInput.value.trim();
+    const roomId = roomIdInput.value.trim();
+    if (!playerName || !roomId) {
+        addHistoryMessage("Pseudo et ID de room requis pour rejoindre");
+        return;
+    }
+    currentRoomId = roomId;
+    openWebsocket(playerName);
+});
 
 form.addEventListener("submit", async (e) => {
     e.preventDefault();
-    let word = input.value.trim().toLowerCase();
-    if (!word) return;
+    if (!currentRoomId) {
+        addHistoryMessage("Rejoignez ou créez une room avant de jouer");
+        return;
+    }
 
-     if (entries.some(e => e.word === word)) {
-    addHistoryMessage(`Mot déjà proposé : ${word}`);
-    input.value = "";
-    return;
-}
+    if (roomLocked && currentMode === "race") {
+        addHistoryMessage("La course est terminée dans cette room.");
+        return;
+    }
 
-    const res = await fetch(`/guess?word=${word}`, { method: "POST" });
+    const word = input.value.trim().toLowerCase();
+    const playerName = playerNameInput.value.trim();
+    if (!word || !playerName) return;
+
+    const res = await fetch(`/rooms/${currentRoomId}/guess`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ word, player_name: playerName })
+    });
+
     const data = await res.json();
+    if (!res.ok) {
+        addHistoryMessage(data.message || data.error || "Erreur lors de la proposition");
+        input.value = "";
+        return;
+    }
 
-    let entry;
-
-    if (data.exists) {
-
-        entry = {
+    // Fallback si la websocket n'est pas connectée
+    if (!websocket || websocket.readyState !== WebSocket.OPEN) {
+        addEntry({
             word,
-            temp: data.temperature,
-            progression: Math.round(data.similarity * 1000),
-        };
+            temp: data.temperature ?? null,
+            progression: data.progression ?? 0,
+            player_name: playerName,
+        });
+        renderScoreboard(data.scoreboard || []);
     }
 
-    if (!entries.some(e => e.word === word)) {
-    entries.push(entry);
-    }
-    renderHistory(); // TRI + ANIMATION
-
-    // gestion des messages & confettis
-    if (data.exists && data.similarity >= 0.99) {
-        triggerConfetti();
-        addHistoryMessage(`🎉 BINGO ! Mot trouvé : ${word}`);
-    } else if (data.exists) {
-        addHistoryMessage(`🔥 ${word} → ${data.temperature} °C`);
-    } else {
-        addHistoryMessage(`❓ ${word} inconnu`);
+    if (data.locked) {
+        roomLocked = true;
     }
 
     input.value = "";
 });
 
-/* ---------- AFFICHAGE AVEC TRI ---------- */
+function openWebsocket(playerName) {
+    if (!currentRoomId) return;
+
+    if (websocket) {
+        websocket.close();
+    }
+
+    const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+    websocket = new WebSocket(`${protocol}://${window.location.host}/rooms/${currentRoomId}/ws?player_name=${encodeURIComponent(playerName)}`);
+
+    websocket.onopen = () => {
+        setRoomInfo(`Connecté à la room ${currentRoomId} (${currentMode})`);
+    };
+
+    websocket.onmessage = (event) => {
+        const data = JSON.parse(event.data);
+
+        if (data.error) {
+            addHistoryMessage(data.message || data.error);
+            return;
+        }
+
+        switch (data.type) {
+            case "state_sync":
+                entries = (data.history || []).map(entry => ({
+                    word: entry.word,
+                    temp: entry.temperature,
+                    progression: entry.progression,
+                    player_name: entry.player_name,
+                }));
+                currentMode = data.mode;
+                roomLocked = data.locked;
+                renderHistory();
+                renderScoreboard(data.scoreboard || []);
+                setRoomInfo(`Room ${currentRoomId} (${currentMode}) prête.`);
+                break;
+            case "guess":
+                addEntry({
+                    word: data.word,
+                    temp: data.temperature,
+                    progression: data.progression,
+                    player_name: data.player_name,
+                });
+                break;
+            case "scoreboard_update":
+                renderScoreboard(data.scoreboard || []);
+                currentMode = data.mode || currentMode;
+                roomLocked = data.locked;
+                if (data.victory && data.winner) {
+                    const label = currentMode === "race" ? "a gagné la course" : "a trouvé le mot";
+                    addHistoryMessage(`🎉 ${data.winner} ${label} !`);
+                    triggerConfetti();
+                }
+                updateRoomStatus();
+                break;
+            case "victory":
+                addHistoryMessage(`🎉 ${data.player_name} a trouvé le mot !`);
+                roomLocked = true;
+                triggerConfetti();
+                updateRoomStatus();
+                break;
+            default:
+                break;
+        }
+    };
+
+    websocket.onclose = () => {
+        setRoomInfo("Déconnecté");
+    };
+}
+
+function addEntry(entry) {
+    entries.push(entry);
+    renderHistory();
+}
 
 function renderHistory() {
     history.innerHTML = "";
 
-    // Tri décroissant par température
-    entries.sort((a, b) => {
-        const ta = a.temp ?? -9999;
-        const tb = b.temp ?? -9999;
-        return tb - ta;
-    });
+    entries.sort((a, b) => (b.progression ?? 0) - (a.progression ?? 0));
 
     let index = 1;
     for (const e of entries) {
         const row = document.createElement("div");
         row.className = "line";
 
-       const num = `<div class="num">${index}&nbsp;</div>`;
-
+        const num = `<div class="num">${index}&nbsp;</div>`;
         const word = `<div class="word">${e.word}</div>`;
+        const player = `<div class="player">${e.player_name || "?"}</div>`;
 
-        if (e.temp === null) {
+        if (e.temp === null || e.temp === undefined) {
             row.innerHTML = `
                 ${num}
+                ${player}
                 ${word}
                 <div class="icon">❓</div>
                 <div class="temp">—</div>
@@ -79,6 +205,7 @@ function renderHistory() {
         } else {
             row.innerHTML = `
                 ${num}
+                ${player}
                 ${word}
                 <div class="icon">${getIcon(e.progression)}</div>
                 <div class="temp">${e.temp}°C</div>
@@ -88,8 +215,7 @@ function renderHistory() {
 
         history.appendChild(row);
 
-        // ANIMATION → après insertion (fixe l’erreur fill=null)
-        if (e.progression !== null) {
+        if (e.progression !== null && e.progression !== undefined) {
             animateBar(row.querySelector(".fill"), e.progression);
         }
 
@@ -97,12 +223,47 @@ function renderHistory() {
     }
 }
 
-/* ----------- ANIMATION DOUCE DE LA BARRE ----------- */
+function renderScoreboard(data) {
+    scoreboard.innerHTML = "";
+    const table = document.createElement("div");
+    table.className = "scoreboard-table";
+
+    const header = document.createElement("div");
+    header.className = "scoreboard-row header";
+    header.innerHTML = `
+        <div>Joueur</div>
+        <div>Essais</div>
+        <div>Meilleure similitude</div>
+    `;
+    table.appendChild(header);
+
+    for (const entry of data) {
+        const row = document.createElement("div");
+        row.className = "scoreboard-row";
+        row.innerHTML = `
+            <div>${entry.player_name}</div>
+            <div>${entry.attempts}</div>
+            <div>${Math.round((entry.best_similarity || 0) * 100)}%</div>
+        `;
+        table.appendChild(row);
+    }
+
+    scoreboard.appendChild(table);
+    updateRoomStatus();
+}
+
+function updateRoomStatus() {
+    if (!currentRoomId) {
+        setRoomInfo("Aucune room active");
+        return;
+    }
+    const status = roomLocked && currentMode === "race" ? "(verrouillée)" : "";
+    setRoomInfo(`Room ${currentRoomId} — mode ${currentMode} ${status}`);
+}
 
 function animateBar(fillElement, progression) {
     if (!fillElement) return;
-
-    const target = progression / 10; // 0 à 100 %
+    const target = progression / 10;
     let width = 0;
 
     fillElement.style.background = getColor(progression);
@@ -113,12 +274,10 @@ function animateBar(fillElement, progression) {
 
         if (width >= target) {
             clearInterval(timer);
-            fillElement.style.width = target + "%"; // final
+            fillElement.style.width = target + "%";
         }
     }, 10);
 }
-
-/* ---------- ICONES / COULEURS ---------- */
 
 function getIcon(value) {
     if (value >= 900) return "💥";
@@ -137,8 +296,6 @@ function getColor(value) {
     return "#4da3ff";
 }
 
-/* ---------- CONFETTIS ---------- */
-
 function triggerConfetti() {
     confetti({
         particleCount: 900,
@@ -147,15 +304,13 @@ function triggerConfetti() {
     });
 }
 
-/* ---------- MESSAGES D’INFO ---------- */
-
 function addHistoryMessage(text) {
     const messages = document.getElementById("messages");
-    messages.innerHTML = "";  // efface les anciens messages
+    messages.innerHTML = "";
 
     const msg = document.createElement("div");
     msg.className = "log";
     msg.textContent = text;
 
-    messages.appendChild(msg); // affiche uniquement le dernier
+    messages.appendChild(msg);
 }

--- a/static/style.css
+++ b/static/style.css
@@ -10,10 +10,10 @@ body {
 
 .layout {
     display: flex;
-    gap: 30px;
+    gap: 20px;
     justify-content: center;
     align-items: flex-start;
-    max-width: 1200px;
+    max-width: 1400px;
     margin: auto;
 }
 
@@ -27,6 +27,9 @@ body {
     box-shadow: 0 3px 10px rgba(0,0,0,0.25);
     color: #4d3a00;
     flex-shrink: 0;
+    position: sticky;
+    top: 40px;
+    height: fit-content;
 }
 
 .legend h2 {
@@ -57,7 +60,7 @@ body {
 
 #container {
     flex-grow: 1;
-    max-width: 600px;
+    max-width: 680px;
 }
 
 #container h1 {
@@ -69,6 +72,39 @@ form {
     display: flex;
     gap: 10px;
     margin-bottom: 20px;
+}
+
+.room-panel {
+    background: #2d3e50;
+    padding: 15px;
+    border-radius: 12px;
+    margin-bottom: 16px;
+    box-shadow: 0 3px 10px rgba(0,0,0,0.25);
+}
+
+.room-form {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.room-form label {
+    display: flex;
+    flex-direction: column;
+    font-size: 14px;
+    gap: 6px;
+}
+
+.room-actions {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 8px;
+}
+
+.room-info {
+    font-size: 14px;
+    opacity: 0.85;
 }
 
 input {
@@ -118,7 +154,7 @@ button:hover {
     padding: 10px;
     margin: 10px 0;
     display: grid;
-    grid-template-columns: 40px 100px 40px 80px 1fr;
+    grid-template-columns: 40px 120px 120px 60px 80px 1fr;
     align-items: center;
     gap: 12px;
 }
@@ -133,6 +169,11 @@ button:hover {
 .word {
     font-size: 18px;
     font-weight: bold;
+}
+
+.player {
+    font-size: 14px;
+    opacity: 0.8;
 }
 
 /* Température */
@@ -156,11 +197,41 @@ button:hover {
     transition: width 0.4s ease-out;
 }
 
+.scoreboard-panel {
+    background: #1c2733;
+    padding: 20px;
+    border-radius: 14px;
+    width: 260px;
+    color: #fff;
+    box-shadow: 0 3px 10px rgba(0,0,0,0.25);
+}
+
+.scoreboard-table {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.scoreboard-row {
+    display: grid;
+    grid-template-columns: 1fr 70px 130px;
+    gap: 10px;
+    padding: 8px 10px;
+    background: #2d3e50;
+    border-radius: 8px;
+    align-items: center;
+}
+
+.scoreboard-row.header {
+    background: transparent;
+    font-weight: bold;
+}
+
 /* ----------- Responsive adjustments ----------- */
 @media (max-width: 600px) {
     .line {
-        grid-template-columns: 25px 1fr 40px 60px 1fr;
-        gap: 8px;
+        grid-template-columns: 25px 1fr 1fr 40px 60px;
+        gap: 6px;
     }
 
     .legend {
@@ -169,39 +240,6 @@ button:hover {
 }
 
 /* ======== LAYOUT GLOBAL ======== */
-
-.layout {
-    display: flex;
-    justify-content: center;
-    align-items: flex-start;
-    gap: 50px;
-    padding: 40px;
-}
-
-/* ======== COLONNE GAUCHE (TABLEAU) ======== */
-
-.legend {
-    position: sticky;
-    top: 40px;
-    background: #f7d84b;
-    padding: 22px 30px;
-    border-radius: 18px;
-    width: 260px;
-    height: fit-content;
-    box-shadow: 0 3px 10px rgba(0,0,0,0.25);
-}
-
-/* ======== COLONNE CENTRALE (JEU) ======== */
-
-.game-area {
-    width: 650px;
-    max-width: 90vw;
-}
-
-.game-area h1 {
-    text-align: center;
-    margin-bottom: 20px;
-}
 
 /* RESPONSIVE : mobile → tableau passe au-dessus */
 @media (max-width: 900px) {
@@ -214,5 +252,13 @@ button:hover {
         position: relative;
         top: 0;
         margin-bottom: 30px;
+    }
+
+    .room-form {
+        grid-template-columns: 1fr;
+    }
+
+    .scoreboard-panel {
+        width: 100%;
     }
 }


### PR DESCRIPTION
## Summary
- add room and player state management with persistent storage for multiplayer sessions
- extend FastAPI app with room creation/guess endpoints and WebSocket broadcasting for guesses and scoreboards
- update the frontend with room join/create flows, scoreboard UI, and real-time updates via WebSocket

## Testing
- `uvicorn app:app --host 0.0.0.0 --port 8000` *(fails: model file frWac_no_postag_phrase_500_cbow_cut10_stripped.bin is missing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69272f7d676083298fde6a00237394fe)