### PR TITLE
Add dependency list and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Cemantix Python
+
+## Installation
+
+Installez les dépendances Python nécessaires via :
+
+```bash
+pip install -r requirements.txt
+```
+
+Assurez-vous de disposer du modèle `frWac_no_postag_phrase_500_cbow_cut10_stripped.bin` dans un dossier `model/` à la racine du projet, conformément au chemin utilisé dans `app.py`.
+
+## Démarrage de l'application
+
+Après installation des dépendances et ajout du modèle, lancez l'API avec :
+
+```bash
+uvicorn app:app --host 0.0.0.0 --port 1256
+```
+
+L'application expose une interface web servie depuis le dossier `static/`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+starlette==0.36.3
+pydantic==2.6.4
+gensim==4.3.2
+numpy==1.26.4


### PR DESCRIPTION
## Summary
- add a requirements.txt with pinned FastAPI stack and machine learning dependencies
- document installation and application start commands in a new README

## Testing
- pip install -r requirements.txt


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a0e730a748329b99eeaf732d65324)