### PR TITLE
Handle definition game initialization failures

### DIFF
--- a/app.py
+++ b/app.py
@@ -202,8 +202,12 @@ def create_room(payload: CreateRoomRequest):
         return JSONResponse(status_code=500, content={"message": "Le modèle Cémantix n'est pas chargé sur le serveur."})
 
     mode = payload.mode if payload.mode in {"coop", "race", "blitz", "daily"} else "coop"
-    room = room_manager.create_room(payload.game_type, mode, payload.player_name)
-    
+    try:
+        room = room_manager.create_room(payload.game_type, mode, payload.player_name)
+    except Exception as exc:
+        error_message = "Impossible de créer une partie de définition pour le moment." if payload.game_type == "definition" else "Erreur lors de la création de la partie."
+        return JSONResponse(status_code=503, content={"message": error_message, "detail": str(exc)})
+
     if payload.mode == "blitz" and payload.duration > 0:
         room.duration = payload.duration
         room.end_time = time.time() + payload.duration

--- a/core/games.py
+++ b/core/games.py
@@ -231,6 +231,7 @@ class DefinitionEngine(GameEngine):
         print("[DEF] Impossible de trouver un mot valide.")
         self.target_word = None
         self.definition = None
+        raise RuntimeError("Aucune définition disponible après plusieurs tentatives")
 
     # -------------------------------------------------------
     # 4) Guess

--- a/core/rooms.py
+++ b/core/rooms.py
@@ -153,11 +153,14 @@ class RoomManager:
 
     def create_room(self, game_type: str, mode: str, creator_name: str) -> RoomState:
         room_id = uuid.uuid4().hex[:8]
-        
+
         engine: GameEngine
         if game_type == "definition":
             engine = DefinitionEngine(self.model)
-            engine.new_game()
+            try:
+                engine.new_game()
+            except Exception as exc:
+                raise RuntimeError("Impossible d'initialiser le jeu de définition") from exc
         elif game_type == "intruder":
             engine = IntruderEngine(self.model)
             engine.new_game()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ starlette==0.36.3
 pydantic==2.6.4
 gensim==4.3.2
 numpy==1.26.4
+httpx==0.27.2
+scipy==1.13.1
+requests==2.32.3

--- a/tests/test_rooms_definition_failure.py
+++ b/tests/test_rooms_definition_failure.py
@@ -1,0 +1,71 @@
+from unittest.mock import patch
+
+import sys
+import types
+
+from fastapi.testclient import TestClient
+
+# Stub minimal gensim modules to éviter le chargement réel du modèle et ses dépendances
+class _DummyKeyedVectors:
+    @classmethod
+    def load_word2vec_format(cls, *args, **kwargs):
+        class _DummyModel:
+            key_to_index = {}
+
+            def get_vecattr(self, word, attr):
+                return 0
+
+        return _DummyModel()
+
+
+_fake_gensim_models = types.ModuleType("gensim.models")
+_fake_gensim_models.KeyedVectors = _DummyKeyedVectors
+_fake_gensim = types.ModuleType("gensim")
+_fake_gensim.models = _fake_gensim_models
+sys.modules.setdefault("gensim", _fake_gensim)
+sys.modules.setdefault("gensim.models", _fake_gensim_models)
+
+import app as app_module
+from core.rooms import RoomManager
+
+
+class FakeModel:
+    def __init__(self):
+        self.key_to_index = {"alpha": 0, "bravo": 1, "charlie": 2}
+
+    def get_vecattr(self, word, attr):
+        return 60000
+
+
+class FakeResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+    def json(self):
+        return {}
+
+
+def test_definition_room_creation_failure_returns_503():
+    # Prépare un RoomManager isolé avec un modèle factice
+    fake_model = FakeModel()
+    app_module.room_manager = RoomManager(fake_model)
+    client = TestClient(app_module.app)
+
+    # Forcer les appels au Wiktionnaire à échouer
+    with patch("core.games.requests.get", return_value=FakeResponse(status_code=500)):
+        response = client.post(
+            "/rooms",
+            json={
+                "player_name": "Alice",
+                "mode": "coop",
+                "game_type": "definition",
+                "duration": 0,
+            },
+        )
+
+    assert response.status_code == 503
+    body = response.json()
+    assert "message" in body
+    assert "Impossible de créer" in body["message"]
+    # Aucune room ne doit avoir été créée après l'erreur
+    assert len(app_module.room_manager.rooms) == 0


### PR DESCRIPTION
## Summary
- Raise an explicit error when DefinitionEngine cannot find a word and propagate room creation failures
- Return a 503 response from /rooms with a clear message when definition game initialization fails
- Add regression coverage for definition room creation failures and include missing test dependencies

## Testing
- python -m pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c239aafc48329a4b516f5760d0648)