### PR TITLE
Enable configurable SoundCloud playlist in hub

### DIFF
--- a/static/hub.html
+++ b/static/hub.html
@@ -228,7 +228,7 @@
         <div class="footer-brand">
             <span style="color:var(--accent); font-size:1.5rem;">●</span> ARCADE HUB
         </div>
-        
+
         <p class="footer-copy">
             &copy; 2024 • Fait avec <span class="heart-beat">♥</span> et du Python, par Julien et Alexi.
         </p>
@@ -241,29 +241,37 @@
     </div>
 </footer>
 
-<!-- --- Musique de fond Mario-like --- -->
-<audio id="bg-music" src="/static/music/Hub.mp3" loop preload="auto"></audio>
-
-<div id="music-toggle"
-     style="
-        position: fixed;
-        top: 80px;
-        right: 20px;
-        width: 45px;
-        height: 45px;
-        background: var(--card);
-        border: 2px solid var(--accent);
-        border-radius: 50%;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        cursor: pointer;
-        box-shadow: 0 3px 8px rgba(0,0,0,0.2);
-        z-index: 9999;
-     ">
-    <span id="music-icon" style="font-size: 1.4rem;">🔊</span>
+<!-- --- Musique de fond via SoundCloud --- -->
+<div class="music-controls">
+    <div class="music-header">
+        <div class="music-title">Playlist SoundCloud</div>
+        <button id="music-toggle" class="music-toggle-btn" aria-label="Mettre en lecture ou pause">
+            <span id="music-icon" aria-hidden="true">🔊</span>
+        </button>
+    </div>
+    <form id="playlist-form" class="music-form">
+        <label for="playlist-input">Collez l'URL d'une playlist SoundCloud pour la diffuser sur le hub.</label>
+        <div class="music-input-row">
+            <input id="playlist-input" type="url" placeholder="https://soundcloud.com/monartiste/sets/ma-playlist" required />
+            <button type="submit" class="btn">Charger</button>
+        </div>
+        <button type="button" class="btn btn-outline" id="use-default-playlist">Utiliser la playlist par défaut</button>
+        <p class="music-hint">Astuce : choisissez une playlist publique sur SoundCloud. Le lecteur s'actualise dès que vous validez.</p>
+    </form>
+    <div class="music-player-wrapper">
+        <iframe
+            id="sc-player"
+            class="music-player"
+            title="Lecteur SoundCloud"
+            scrolling="no"
+            frameborder="no"
+            allow="autoplay"
+            src="https://w.soundcloud.com/player/?url=&auto_play=false&hide_related=true&show_comments=false&show_user=false&show_reposts=false&visual=false">
+        </iframe>
+    </div>
 </div>
 
+<script src="https://w.soundcloud.com/player/api.js"></script>
 <script type="module" src="/static/js/music_hub.js"></script>
 
 

--- a/static/js/music_hub.js
+++ b/static/js/music_hub.js
@@ -1,20 +1,101 @@
-let musicEnabled = false;
-const music = document.getElementById("bg-music");
-const toggle = document.getElementById("music-toggle");
-const icon = document.getElementById("music-icon");
+const DEFAULT_PLAYLIST_URL = "https://soundcloud.com/monstercat/sets/monstercat-instinct-vol-1";
 
-// Volume de fond (0.0 → 1.0)
-music.volume = 0.25;
+const toggleButton = document.getElementById("music-toggle");
+const toggleIcon = document.getElementById("music-icon");
+const playlistInput = document.getElementById("playlist-input");
+const playlistForm = document.getElementById("playlist-form");
+const defaultButton = document.getElementById("use-default-playlist");
+const playerFrame = document.getElementById("sc-player");
 
-// Chrome bloque l’autoplay : on active au clic
-toggle.addEventListener("click", () => {
-    if (!musicEnabled) {
-        music.play();
-        icon.textContent = "🔈";
-        musicEnabled = true;
+const widgetApiReady = new Promise((resolve) => {
+    if (window.SC && window.SC.Widget) {
+        resolve();
+        return;
+    }
+
+    const apiScript = document.querySelector('script[src*="player/api.js"]');
+    if (apiScript) {
+        apiScript.addEventListener("load", () => resolve());
     } else {
-        music.pause();
-        icon.textContent = "🔊";
-        musicEnabled = false;
+        resolve();
     }
 });
+
+let widget = null;
+let isPlaying = false;
+
+function buildPlayerSrc(url, autoPlay = false) {
+    const base = "https://w.soundcloud.com/player/";
+    const params = new URLSearchParams({
+        url,
+        auto_play: autoPlay,
+        hide_related: true,
+        show_comments: false,
+        show_user: false,
+        show_reposts: false,
+        visual: false,
+    });
+
+    return `${base}?${params.toString()}`;
+}
+
+function updateIcon() {
+    toggleIcon.textContent = isPlaying ? "🔈" : "🔊";
+}
+
+function bindWidgetEvents(currentWidget) {
+    currentWidget.bind(window.SC.Widget.Events.PLAY, () => {
+        isPlaying = true;
+        updateIcon();
+    });
+
+    currentWidget.bind(window.SC.Widget.Events.PAUSE, () => {
+        isPlaying = false;
+        updateIcon();
+    });
+
+    currentWidget.bind(window.SC.Widget.Events.FINISH, () => {
+        isPlaying = false;
+        updateIcon();
+    });
+}
+
+function loadPlaylist(url, autoPlay = true) {
+    playerFrame.src = buildPlayerSrc(url, autoPlay);
+    widget = window.SC.Widget(playerFrame);
+    bindWidgetEvents(widget);
+}
+
+function init() {
+    widgetApiReady.then(() => {
+        if (!window.SC || !window.SC.Widget) {
+            console.warn("L'API SoundCloud n'est pas disponible.");
+            return;
+        }
+
+        playlistInput.value = DEFAULT_PLAYLIST_URL;
+        loadPlaylist(DEFAULT_PLAYLIST_URL, false);
+
+        toggleButton.addEventListener("click", () => {
+            if (!widget) return;
+            widget.toggle();
+        });
+
+        playlistForm.addEventListener("submit", (event) => {
+            event.preventDefault();
+            if (!playlistInput.value) return;
+            loadPlaylist(playlistInput.value, true);
+        });
+
+        defaultButton.addEventListener("click", () => {
+            playlistInput.value = DEFAULT_PLAYLIST_URL;
+            loadPlaylist(DEFAULT_PLAYLIST_URL, true);
+        });
+    });
+}
+
+if (document.readyState !== "loading") {
+    init();
+} else {
+    document.addEventListener("DOMContentLoaded", init);
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1090,3 +1090,96 @@ input:disabled {
         opacity: 0;
     }
 }
+
+/* --- MUSIQUE / PLAYLIST --- */
+.music-controls {
+    position: fixed;
+    right: 20px;
+    top: 80px;
+    width: min(420px, 90vw);
+    background: var(--surface);
+    border: 2px solid var(--border);
+    border-radius: var(--radius-l);
+    box-shadow: var(--shadow-soft);
+    padding: 18px;
+    z-index: 1200;
+}
+
+.music-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+
+.music-title {
+    font-family: var(--font-heading);
+    font-weight: 700;
+    color: var(--text-main);
+}
+
+.music-toggle-btn {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    border: 2px solid var(--accent);
+    background: var(--surface);
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+    font-size: 1.3rem;
+    transition: transform 0.2s var(--ease-bounce), box-shadow 0.2s;
+    box-shadow: 0 3px 8px rgba(0,0,0,0.08);
+}
+
+.music-toggle-btn:hover { transform: translateY(-2px) scale(1.02); }
+
+.music-form {
+    display: grid;
+    gap: 10px;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.music-input-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 10px;
+}
+
+.music-form .btn {
+    padding: 14px 20px;
+    font-size: 1rem;
+}
+
+.music-form .btn-outline {
+    padding: 12px 16px;
+}
+
+.music-hint {
+    margin: 0;
+    font-size: 0.9rem;
+}
+
+.music-player-wrapper {
+    margin-top: 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-m);
+    overflow: hidden;
+}
+
+.music-player {
+    width: 100%;
+    height: 140px;
+}
+
+@media (max-width: 640px) {
+    .music-controls {
+        left: 50%;
+        transform: translateX(-50%);
+        right: auto;
+        top: auto;
+        bottom: 20px;
+    }
+}


### PR DESCRIPTION
## Summary
- add a SoundCloud playlist panel to the hub with play/pause toggle and player embed
- allow users to load their own playlist URLs or restore a default soundtrack
- style the new music controls for desktop and mobile visibility

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c2478c47483298b063bae4645b3c0)