### PR TITLE
Load music from playlist

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,8 @@ except Exception as e:
 
 room_manager = RoomManager(model)
 app.mount("/static", StaticFiles(directory="static"), name="static")
+# Rendre la playlist musicale disponible côté client pour éviter le hardcode des liens
+app.mount("/music", StaticFiles(directory="music"), name="music")
 
 
 class CreateRoomRequest(BaseModel):
@@ -345,18 +347,19 @@ async def websocket_endpoint(websocket: WebSocket, room_id: str):
 
     # Envoi de l'état initial (Sync)
     try:
-        await websocket.send_json(
-            {
-                "type": "state_sync",
-                "history": history_payload,
-                "scoreboard": build_scoreboard(room),
-                "mode": room.mode,
-                "locked": room.locked,
-                "game_type": room.game_type,
-                "public_state": public_state,
-                "end_time": room.end_time
-            }
-        )
+                await websocket.send_json(
+                    {
+                        "type": "state_sync",
+                        "history": history_payload,
+                        "scoreboard": build_scoreboard(room),
+                        "mode": room.mode,
+                        "locked": room.locked,
+                        "game_type": room.game_type,
+                        "public_state": public_state,
+                        "end_time": room.end_time,
+                        "duration": room.duration,
+                    }
+                )
         
         await connections.broadcast(room_id, {
             "type": "scoreboard_update",

--- a/static/hub.html
+++ b/static/hub.html
@@ -269,6 +269,9 @@
     scrolling="no"
     frameborder="no"
     allow="autoplay"
+    data-sound-url=""
+    data-mode-tracks='{}'
+    data-game-duration-tracks='{}'
 ></iframe>
 
 <script src="https://w.soundcloud.com/player/api.js"></script>

--- a/static/index.html
+++ b/static/index.html
@@ -101,6 +101,44 @@
     </form>
 </div>
 
+<!-- --- Musique de fond par page et par mode --- -->
+<div id="music-toggle"
+     style="
+        position: fixed;
+        top: 80px;
+        right: 20px;
+        width: 45px;
+        height: 45px;
+        background: var(--card);
+        border: 2px solid var(--accent);
+        border-radius: 50%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        cursor: pointer;
+        box-shadow: 0 3px 8px rgba(0,0,0,0.2);
+        z-index: 9999;
+     ">
+    <span id="music-icon" style="font-size: 1.4rem;">🔊</span>
+</div>
+
+<iframe
+    id="sc-player"
+    title="Lecteur SoundCloud"
+    style="display:none;"
+    scrolling="no"
+    frameborder="no"
+    allow="autoplay"
+    data-sound-url=""
+    data-mode-tracks='{}'
+    data-game-tracks='{}'
+    data-game-mode-tracks='{}'
+    data-game-duration-tracks='{}'
+></iframe>
+
+<script src="https://w.soundcloud.com/player/api.js"></script>
+<script type="module" src="/static/js/music_hub.js"></script>
+
 <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
 <script type="module" src="/static/js/main.js"></script>
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -209,6 +209,12 @@ const params = new URLSearchParams(window.location.search);
 const roomId = params.get("room");
 const playerName = params.get("player");
 
+function updateMusicContext(gameType, mode, duration) {
+    if (window.musicManager && typeof window.musicManager.setContext === "function") {
+        window.musicManager.setContext({ gameType, mode, duration });
+    }
+}
+
 if (window.location.pathname === "/game") {
     const params = new URLSearchParams(window.location.search);
     const roomId = params.get("room");
@@ -250,7 +256,8 @@ function initGameConnection(roomId, playerName) {
                 state.currentMode = data.mode;
                 state.roomLocked = data.locked;
                 if (data.mode === "blitz" && data.end_time) startTimer(data.end_time);
-                
+                updateMusicContext(data.game_type, data.mode, data.duration);
+
                 // Chargement historique chat
                 if (data.chat_history) {
                     data.chat_history.forEach(msg => addChatMessage(msg.player_name, msg.content));

--- a/static/js/music_hub.js
+++ b/static/js/music_hub.js
@@ -1,8 +1,7 @@
-const SOUNDTRACK_URL = "https://soundcloud.com/monstercat/sets/monstercat-instinct-vol-1";
+const PLAYLIST_PATH = "/music/Playlist.md";
 
 const toggleButton = document.getElementById("music-toggle");
 const toggleIcon = document.getElementById("music-icon");
-
 const playerFrame = document.getElementById("sc-player");
 
 const widgetApiReady = new Promise((resolve) => {
@@ -21,8 +20,116 @@ const widgetApiReady = new Promise((resolve) => {
 
 let widget = null;
 let isPlaying = false;
+let currentGameType = null;
+let currentMode = null;
+let currentDuration = null;
+
+function parseDataJson(value) {
+    if (!value) return {};
+    try {
+        return JSON.parse(value);
+    } catch (err) {
+        console.warn("Configuration musique invalide :", err);
+        return {};
+    }
+}
+
+function parsePlaylistMarkdown(markdown) {
+    const lines = markdown.split(/\r?\n/);
+    const data = {};
+    let currentSection = null;
+    let currentSub = null;
+
+    for (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (!line) continue;
+
+        if (line.startsWith("# ")) {
+            currentSection = line.slice(2).toLowerCase();
+            data[currentSection] = data[currentSection] || {};
+            currentSub = null;
+            continue;
+        }
+
+        if (line.startsWith("## ")) {
+            currentSub = line.slice(3).toLowerCase();
+            data[currentSection] = data[currentSection] || {};
+            data[currentSection][currentSub] = data[currentSection][currentSub] || null;
+            continue;
+        }
+
+        if (line.startsWith("http")) {
+            if (currentSection && currentSub) {
+                data[currentSection][currentSub] = line;
+            } else if (currentSection) {
+                data[currentSection] = line;
+            }
+        }
+    }
+
+    return data;
+}
+
+function mapPlaylistToConfig(playlist) {
+    if (!playlist || typeof playlist !== "object") return null;
+
+    const normalizeSeconds = (label) => {
+        const match = label.match(/(\d+)/);
+        if (!match) return null;
+        const minutes = parseInt(match[1], 10);
+        return Number.isFinite(minutes) ? String(minutes * 60) : null;
+    };
+
+    const config = {
+        defaultTrack: typeof playlist.hub === "string" ? playlist.hub : null,
+        modeTracks: {},
+        gameTracks: {},
+        gameModeTracks: {},
+        gameDurationTracks: {},
+    };
+
+    // Dictionnary / Definition (coop & blitz)
+    const dictionnary = playlist.dictionnary || playlist.dictionnario || {};
+    if (typeof dictionnary === "object") {
+        if (dictionnary.coop) config.modeTracks.coop = dictionnary.coop;
+        if (dictionnary.blitz) config.modeTracks.blitz = dictionnary.blitz;
+        if (!config.gameTracks.definition && dictionnary.coop) {
+            config.gameTracks.definition = dictionnary.coop;
+        }
+    }
+
+    // Cémantix
+    if (playlist.cemantics || playlist.cemantix) {
+        config.gameTracks.cemantix = playlist.cemantics || playlist.cemantix;
+    }
+
+    // Pendu
+    if (playlist.pendu) {
+        config.gameTracks.hangman = playlist.pendu;
+    }
+
+    // Intrus (durée en minutes)
+    const intrus = playlist.intrus || playlist["l'intrus"] || {};
+    if (typeof intrus === "object") {
+        config.gameDurationTracks.intruder = {};
+        Object.entries(intrus).forEach(([label, url]) => {
+            const durationKey = normalizeSeconds(label);
+            if (durationKey && url) {
+                config.gameDurationTracks.intruder[durationKey] = url;
+            }
+        });
+        // Choisir une piste par défaut pour l'intrus si aucune durée ne correspond
+        const firstIntrusTrack = Object.values(config.gameDurationTracks.intruder)[0];
+        if (firstIntrusTrack) {
+            config.gameTracks.intruder = firstIntrusTrack;
+        }
+    }
+
+    return config;
+}
 
 function buildPlayerSrc(url, autoPlay = false) {
+    if (!url) return "";
     const base = "https://w.soundcloud.com/player/";
     const params = new URLSearchParams({
         url,
@@ -38,6 +145,7 @@ function buildPlayerSrc(url, autoPlay = false) {
 }
 
 function updateIcon() {
+    if (!toggleIcon) return;
     toggleIcon.textContent = isPlaying ? "🔈" : "🔊";
 }
 
@@ -59,25 +167,166 @@ function bindWidgetEvents(currentWidget) {
 }
 
 function loadSoundtrack(url, autoPlay = false) {
+    if (!url) {
+        console.warn("Aucune piste de musique définie pour ce contexte.");
+        return;
+    }
 
+    if (!playerFrame) return;
     playerFrame.src = buildPlayerSrc(url, autoPlay);
     widget = window.SC.Widget(playerFrame);
     bindWidgetEvents(widget);
 }
 
-function init() {
+function resolveTrackUrl(config, gameType, mode, durationKey) {
+    const { defaultTrack, modeTracks, gameTracks, gameModeTracks, gameDurationTracks } = config;
+
+    if (durationKey && gameDurationTracks[gameType] && gameDurationTracks[gameType][durationKey]) {
+        return gameDurationTracks[gameType][durationKey];
+    }
+
+    if (gameModeTracks[gameType] && gameModeTracks[gameType][mode]) {
+        return gameModeTracks[gameType][mode];
+    }
+
+    if (modeTracks[mode]) {
+        return modeTracks[mode];
+    }
+
+    if (gameTracks[gameType]) {
+        return gameTracks[gameType];
+    }
+
+    return defaultTrack;
+}
+
+function buildDatasetConfig() {
+    const dataset = playerFrame ? playerFrame.dataset : {};
+    const defaultTrack = dataset.soundUrl || dataset.defaultTrack || null;
+
+    return {
+        defaultTrack,
+        modeTracks: parseDataJson(dataset.modeTracks),
+        gameTracks: parseDataJson(dataset.gameTracks),
+        gameModeTracks: parseDataJson(dataset.gameModeTracks),
+        gameDurationTracks: parseDataJson(dataset.gameDurationTracks),
+        autoPlay: dataset.autoplay === "true"
+    };
+}
+
+function mergeConfigs(base, override) {
+    if (!override) return base;
+
+    const mergeNested = (src = {}, add = {}) => {
+        const merged = { ...src };
+        Object.entries(add).forEach(([key, value]) => {
+            merged[key] = { ...(src[key] || {}), ...(value || {}) };
+        });
+        return merged;
+    };
+
+    return {
+        defaultTrack: override.defaultTrack || base.defaultTrack,
+        autoPlay: typeof override.autoPlay === "boolean" ? override.autoPlay : base.autoPlay,
+        modeTracks: { ...base.modeTracks, ...override.modeTracks },
+        gameTracks: { ...base.gameTracks, ...override.gameTracks },
+        gameModeTracks: mergeNested(base.gameModeTracks, override.gameModeTracks),
+        gameDurationTracks: mergeNested(base.gameDurationTracks, override.gameDurationTracks),
+    };
+}
+
+async function fetchPlaylistConfig() {
+    try {
+        const response = await fetch(PLAYLIST_PATH, { cache: "no-store" });
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+
+        const markdown = await response.text();
+        const parsed = parsePlaylistMarkdown(markdown);
+        return mapPlaylistToConfig(parsed);
+    } catch (err) {
+        console.warn("Impossible de charger la playlist depuis music/Playlist.md :", err);
+        return null;
+    }
+}
+
+function chooseFallbackTrack(config) {
+    const candidates = [
+        config.defaultTrack,
+        ...Object.values(config.modeTracks || {}),
+        ...Object.values(config.gameTracks || {}),
+    ];
+    return candidates.find(Boolean) || null;
+}
+
+async function init() {
+    if (!playerFrame || !toggleButton || !toggleIcon) return;
+
+    updateIcon();
+
+    const datasetConfig = buildDatasetConfig();
+    const playlistConfig = await fetchPlaylistConfig();
+    const config = mergeConfigs(datasetConfig, playlistConfig);
+
+    if (!config.defaultTrack) {
+        config.defaultTrack = chooseFallbackTrack(config);
+    }
+
     widgetApiReady.then(() => {
         if (!window.SC || !window.SC.Widget) {
             console.warn("L'API SoundCloud n'est pas disponible.");
             return;
         }
 
-        loadSoundtrack(SOUNDTRACK_URL, false);
+        currentGameType = playerFrame.dataset.currentGame || null;
+        currentMode = playerFrame.dataset.currentMode || null;
+        currentDuration = playerFrame.dataset.currentDuration || null;
+        const durationKey = currentDuration ? String(currentDuration) : null;
+
+        const initialTrack = resolveTrackUrl(config, currentGameType, currentMode, durationKey);
+        loadSoundtrack(initialTrack, config.autoPlay);
 
         toggleButton.addEventListener("click", () => {
             if (!widget) return;
             widget.toggle();
         });
+
+        window.musicManager = {
+            setContext({ gameType = currentGameType, mode = currentMode, duration = currentDuration, autoPlay = false } = {}) {
+                currentGameType = gameType;
+                currentMode = mode;
+                currentDuration = duration;
+                const durationKey = duration ? String(duration) : null;
+                const targetUrl = resolveTrackUrl(config, currentGameType, currentMode, durationKey);
+                if (targetUrl) {
+                    loadSoundtrack(targetUrl, autoPlay);
+                }
+            },
+            setMode(mode, autoPlay = false) {
+                this.setContext({ mode, autoPlay });
+            },
+            setTracks(newConfig = {}) {
+                const mergeNested = (target = {}, incoming = {}) => {
+                    const result = { ...target };
+                    Object.entries(incoming).forEach(([key, value]) => {
+                        result[key] = { ...(target[key] || {}), ...(value || {}) };
+                    });
+                    return result;
+                };
+
+                config.modeTracks = { ...config.modeTracks, ...(newConfig.modeTracks || {}) };
+                config.gameTracks = { ...config.gameTracks, ...(newConfig.gameTracks || {}) };
+                config.gameModeTracks = mergeNested(config.gameModeTracks, newConfig.gameModeTracks || {});
+                config.gameDurationTracks = mergeNested(config.gameDurationTracks, newConfig.gameDurationTracks || {});
+                if (newConfig.defaultTrack) config.defaultTrack = newConfig.defaultTrack;
+                const durationKey = currentDuration ? String(currentDuration) : null;
+                const refreshedUrl = resolveTrackUrl(config, currentGameType, currentMode, durationKey);
+                if (refreshedUrl) {
+                    loadSoundtrack(refreshedUrl, false);
+                }
+            },
+        };
     });
 }
 


### PR DESCRIPTION
## Summary
- expose the shared music directory so the playlist markdown is available to clients
- load and merge playlist entries into the music manager to pick tracks per game, mode, or duration and refresh context updates
- drop hardcoded SoundCloud fallbacks in the pages while syncing the game duration to drive soundtrack selection

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c486d57f88329930995ee5c55f776)